### PR TITLE
Starting logout timer as soon as user logs in

### DIFF
--- a/force-app/main/default/lwc/bankistAppMain/bankistAppMain.js
+++ b/force-app/main/default/lwc/bankistAppMain/bankistAppMain.js
@@ -398,6 +398,7 @@ export default class BankistAppMain extends LightningElement {
         console.error(JSON.stringify(error.message), JSON.stringify(error.stack));
       }
     }
+    tick();
     const logoutTimer = setInterval(tick, 1000);
     return logoutTimer;
   }


### PR DESCRIPTION
I noticed when the user logs in to the app, the timer is not starting immediately. To fix this I am calling the timer function before it is used as callback in setInterval method